### PR TITLE
Change Login URL for outside US

### DIFF
--- a/src/CareLink/SupportClasses/CareLinkClientHelpers.vb
+++ b/src/CareLink/SupportClasses/CareLinkClientHelpers.vb
@@ -151,11 +151,12 @@ Public Module CareLinkClientHelpers
 
     ' Get server URL
     Friend Function GetServerURL(country As String) As String
-        Select Case country.GetRegionFromCode
-            Case "North America"
+        Dim countryCode As String = If(String.IsNullOrWhiteSpace(country), "US", country)
+        Dim countryFromCode As String = GetCountryFromCode(countryCode)
+
+        Select Case countryFromCode
+            Case "US"
                 Return "CareLink.MiniMed.com"
-            Case "Europe"
-                Return "CareLink.MiniMed.eu"
             Case Else
                 Return "CareLink.MiniMed.eu"
         End Select


### PR DESCRIPTION
I tested your code from Canada and was not able to log in since it was the code was using the US link (.com). 
I tested the login flow from other repos and realised the .com link is only for US clients. 
For example, see [carelink_client.py](https://github.com/ondrej1024/carelink-python-client/blob/4e01d510968edbdc6fd21ba0dc542fbee6c30bc2/carelink_client.py#L104).

When I changed it, It started working.